### PR TITLE
remove  in reply to mention

### DIFF
--- a/server/_lib/parser.ts
+++ b/server/_lib/parser.ts
@@ -89,8 +89,8 @@ export const getSyndication = async (id: string) => {
 
 export const getTweetContent = (data: TweetSyndication, options: TweetOptions) => {
   try {
-    const { entities, user, card, text, quoted_tweet, photos, video } = data
-    let html = text
+    const { display_text_range, entities, user, card, text, quoted_tweet, photos, video } = data
+    let html = text.substr(display_text_range[0],)
 
     const meta = {
       user_id: user.id_str,


### PR DESCRIPTION
when the tweet is replying to another tweet, the tweet.text will add the mention example:
"@iam2sw4g @tweek BASTA" instead of "BASTA" so I use display_text_range to remove the mentions