### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/umami.client.ts
+++ b/plugins/umami.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 
 export default defineNuxtPlugin(() => {
   const moduleOptions = {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.